### PR TITLE
Clear composer cache before dep install

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -45,6 +45,7 @@ if [ -n "$PUBLIC_KEY" ] && [ -n "$PRIVATE_KEY" ]; then
 fi
 
 echo "Forcing reinstall of composer deps to ensure perms & reqs..."
+bin/clinotty composer clearcache
 bin/clinotty composer global require hirak/prestissimo
 bin/clinotty composer install
 


### PR DESCRIPTION
Sometimes the caching behavior of composer can cause issues when rebuilding dependencies. (caused me a lot of problems today). This PR simply adds a cache clear to the build script before dependency installation.