### PR TITLE
Improve branding on UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ And the following payment methods:
 
 ### Installing the module manually
 
-1. Download the module from [here](https://github.com/komoju/komoju-woocommerce/archive/master.zip)
+1. Download the module from [here](https://github.com/komoju/komoju-magento/archive/master.zip)
 2. Upload the folder to your magento server
 3. Unzip the folder to the /tmp directory
 ```
@@ -41,7 +41,7 @@ Once the plugin has been installed you will need to configure it. Go to the stor
 
 ### Configuring the Komoju webhook 
 
-To ensure that the WooCommerce plugin works correctly you will need to set up a webhook from your Komoju dashboard to the wordpress instance. To do this you will need to go to your [Webhook page on the Komoju dashboard](https://komoju.com/admin/webhooks) and click "New Webhook". If you don't know what the webhook URL should be you can check the admin page for this plugin on your wordpress instance to see the default address. The secret can be anything you want (as long as you remember it), but you must make sure the following events are ticked:
+To ensure that the Magento plugin works correctly you will need to set up a webhook from your Komoju dashboard to the wordpress instance. To do this you will need to go to your [Webhook page on the Komoju dashboard](https://komoju.com/admin/webhooks) and click "New Webhook". If you don't know what the webhook URL should be you can check the admin page for this plugin on your wordpress instance to see the default address. The secret can be anything you want (as long as you remember it), but you must make sure the following events are ticked:
 
 - payment.authorized
 - payment.captured

--- a/src/app/code/Komoju/Payments/etc/adminhtml/system.xml
+++ b/src/app/code/Komoju/Payments/etc/adminhtml/system.xml
@@ -4,8 +4,8 @@
     <system>
         <section id="payment">
             <group id="komoju_payments" translate="label comment" type="text" sortOrder="5" showInDefault="1" showInStore="1" showInWebsite="1">
-                <label>Komoju</label>
-                <comment>Allows payments by Komoju, dedicated to Japanese online and offline payment gateways.</comment>
+                <label>KOMOJU</label>
+                <comment>Accept Japanese payments with KOMOJU</comment>
                 <attribute type="displayIn">recommended_solutions</attribute>
                 <fieldset_css>complex komoju-section</fieldset_css>
                 <frontend_model>Magento\Paypal\Block\Adminhtml\System\Config\Fieldset\Payment</frontend_model>

--- a/src/app/code/Komoju/Payments/etc/config.xml
+++ b/src/app/code/Komoju/Payments/etc/config.xml
@@ -8,7 +8,7 @@
                 <active>0</active>
                 <order_status>pending_payment</order_status>
                 <currency>JPY</currency>
-                <title>コンビニ / クレジットカード決済 - KOMOJU</title>
+                <title>コンビニ・クレジットカード決済 - KOMOJU</title>
                 <enable_credit_card_payments>1</enable_credit_card_payments>
                 <enable_konbini_payments>1</enable_konbini_payments>
                 <merchant_id />

--- a/src/app/code/Komoju/Payments/etc/config.xml
+++ b/src/app/code/Komoju/Payments/etc/config.xml
@@ -8,7 +8,7 @@
                 <active>0</active>
                 <order_status>pending_payment</order_status>
                 <currency>JPY</currency>
-                <title>Komoju</title>
+                <title>コンビニ / クレジットカード決済 - KOMOJU</title>
                 <enable_credit_card_payments>1</enable_credit_card_payments>
                 <enable_konbini_payments>1</enable_konbini_payments>
                 <merchant_id />

--- a/src/app/code/Komoju/Payments/i18n/en_US.csv
+++ b/src/app/code/Komoju/Payments/i18n/en_US.csv
@@ -6,15 +6,14 @@ Konbini,Konbini
 "Received payment authorization for type: %1. Payment deadline is: %2","Received payment authorization for type: %1. Payment deadline is: %2"
 "Payment was not received before expiry time","Payment was not received before expiry time"
 "Received cancellation notice from Komoju","Received cancellation notice from Komoju"
-"Payment failed","Payment failed"
 "Order has been fully refunded.","Order has been fully refunded."
 "Refund for order created. Amount: %1 %2","Refund for order created. Amount: %1 %2"
 "Unknown event type: %1","Unknown event type: %1"
 "Komoju External Order ID: %1 %2","Komoju External Order ID: %1 %2"
 "Payment Type","Payment Type"
 "Place Order","Place Order"
-Komoju,Komoju
-"Allows payments by Komoju, dedicated to Japanese online and offline payment gateways.","Allows payments by Komoju, dedicated to Japanese online and offline payment gateways."
+KOMOJU,KOMOJU
+"Accept Japanese payments with KOMOJU","Accept Japanese payments with KOMOJU"
 "Enable this Solution","Enable this Solution"
 "This plugin can only work if the store's base currency is one of: JPY","This plugin can only work if the store's base currency is one of: JPY"
 "API Settings","API Settings"

--- a/src/app/code/Komoju/Payments/i18n/ja_JP.csv
+++ b/src/app/code/Komoju/Payments/i18n/ja_JP.csv
@@ -6,15 +6,14 @@ Konbini,コンビニ
 "Received payment authorization for type: %1. Payment deadline is: %2","タイプの支払い承認を受け取りました: %1. お支払い期限は: %2"
 "Payment was not received before expiry time","有効期限が切れる前に支払いが受領されなかった"
 "Received cancellation notice from Komoju","Komojuからキャンセルのお知らせを受け取りました"
-"Payment failed","支払いが失敗しました"
 "Order has been fully refunded.","注文は全額返金されました"
 "Refund for order created. Amount: %1 %2","作成した注文の払い戻し。量: %1 %2"
 "Unknown event type: %1","不明なイベントタイプ: %1"
 "Komoju External Order ID: %1 %2","Komoju 外部注文ID: %1 %2"
 "Payment Type","払いの種類"
 "Place Order","注文する"
-Komoju,Komoju
-"Allows payments by Komoju, dedicated to Japanese online and offline payment gateways.","日本のオンラインおよびオフライン決済ゲートウェイに特化した、Komojuによる決済を可能にします。"
+KOMOJU,KOMOJU
+"Accept Japanese payments with KOMOJU","KOMOJUで日本の支払いを受け入れる"
 "Enable this Solution","このソリューションを有効にする"
 "This plugin can only work if the store's base currency is one of: JPY","このプラグインは、ストアの基本通貨が次のいずれかである場合にのみ機能します: JPY"
 "API Settings","API設定"


### PR DESCRIPTION
Updating the UI to improve on the branding to make sure everything's consistent with how we like to present KOMOJU 😄 

## Screenshots

![image](https://user-images.githubusercontent.com/12392541/84124938-37165380-aa7f-11ea-944b-3310c7a8df15.png)

![image](https://user-images.githubusercontent.com/12392541/84124898-26fe7400-aa7f-11ea-94db-bcaf52c401fc.png)

Regarding the default name for KOMOJU on the checkout page, I couldn't find a way to provide a translation for the default value, so it will be in Japanese for all locales (JA, EN, etc). I don't think this will be a huge problem since most of the customers for this will be Japanese, but this may post a bit of a problem if we want to add support for additional languages later on.
