### PR TITLE
Update webhook url explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Once the plugin has been installed you will need to configure it. Go to the stor
 
 ### Configuring the Komoju webhook 
 
-To ensure that the Magento plugin works correctly you will need to set up a webhook from your Komoju dashboard to the wordpress instance. To do this you will need to go to your [Webhook page on the Komoju dashboard](https://komoju.com/admin/webhooks) and click "New Webhook". If you don't know what the webhook URL should be you can check the admin page for this plugin on your wordpress instance to see the default address. The secret can be anything you want (as long as you remember it), but you must make sure the following events are ticked:
+To ensure that the Magento plugin works correctly you will need to set up a webhook from your Komoju dashboard to the wordpress instance. To do this you will need to go to your [Webhook page on the Komoju dashboard](https://komoju.com/admin/webhooks) and click "New Webhook". The Webhook URL is at `/komoju/hostedpage/webhook` of your Magento website. If your Magento was `https://magento.komoju.com` then your Webhook URL would be `https://magento.komoju.com/komoju/hostedpage/webhook`. The Secret can be anything you want (as long as you remember it), but you must make sure the following events are ticked:
 
 - payment.authorized
 - payment.captured

--- a/src/app/code/Komoju/Payments/etc/adminhtml/system.xml
+++ b/src/app/code/Komoju/Payments/etc/adminhtml/system.xml
@@ -27,8 +27,9 @@
                         <config_path>payment/komoju_payments/secret_key</config_path>
                         <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
                     </field>
-                    <field id="webhook_secret_token" translate="label" type="obscure" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <field id="webhook_secret_token" translate="label comment" type="obscure" showInDefault="1" showInWebsite="1" showInStore="1">
                         <label>Webhook Secret Token</label>
+                        <comment>The webhook URL will be at /komoju/hostedpage/webhook of this site</comment> 
                         <config_path>payment/komoju_payments/webhook_secret_token</config_path>
                         <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
                     </field>

--- a/src/app/code/Komoju/Payments/i18n/en_US.csv
+++ b/src/app/code/Komoju/Payments/i18n/en_US.csv
@@ -20,6 +20,7 @@ KOMOJU,KOMOJU
 "Komoju merchant ID","Komoju merchant ID"
 "Secret Key from Komoju","Secret Key from Komoju"
 "Webhook Secret Token","Webhook Secret Token"
+"The webhook URL will be at /komoju/hostedpage/webhook of this site","The webhook URL will be at /komoju/hostedpage/webhook of this site"
 "Payment Methods","Payment Methods"
 "Allow credit card payments","Allow credit card payments"
 "Allow konbini payments","Allow konbini payments"

--- a/src/app/code/Komoju/Payments/i18n/ja_JP.csv
+++ b/src/app/code/Komoju/Payments/i18n/ja_JP.csv
@@ -20,6 +20,7 @@ KOMOJU,KOMOJU
 "Komoju merchant ID","Komoju 商人ID"
 "Secret Key from Komoju","Komojuの秘密鍵"
 "Webhook Secret Token","Webhookシークレットトークン"
+"The webhook URL will be at /komoju/hostedpage/webhook of this site","webhook URLは、このサイトの/ komoju / hostedpage / webhookにあります"
 "Payment Methods","お支払い方法"
 "Allow credit card payments","クレジットカード決済を許可する"
 "Allow konbini payments","コンビニ支払いを許可する"


### PR DESCRIPTION
The Current README explanation for figuring out the webhook URL is based on the komoju-woocomerce implementation, which does not work for the Magento extension.

I've updated the PR to correctly explain how to figure out the webhook URL, and added a comment on the webhook secret token config field also listing what the webhook route should be. AFAICT, we can get the follow website URL in the comment, since Magento uses XML to configure the config page and there doesn't seem to be a way to easily inject data into it.

## Screenshots
![image](https://user-images.githubusercontent.com/12392541/84216357-9a9a9280-ab0c-11ea-82d4-f585fb19bb62.png)
