### PR TITLE
Add via=magento param to Hosted Page API call

### DIFF
--- a/src/app/code/Komoju/Payments/Controller/HostedPage/Redirect.php
+++ b/src/app/code/Komoju/Payments/Controller/HostedPage/Redirect.php
@@ -149,7 +149,7 @@ class Redirect extends \Magento\Framework\App\Action\Action
             "transaction[return_url]" => $this->_url->getUrl('checkout/onepage/success'),
             "transaction[cancel_url]" => $this->_url->getUrl($cancelUrl),
             "transaction[external_order_num]" => $externalOrderNum,
-            // "via" => "Magento",
+            "via" => "magento",
         ];
     }
 


### PR DESCRIPTION
Adding the via=magento param to the Hosted Page API call so we have a way to track the amount of traffic coming from the magento plugin.