### PR TITLE
set "tax" param to 0 in Redirect.php

### DIFF
--- a/src/app/code/Komoju/Payments/Controller/HostedPage/Redirect.php
+++ b/src/app/code/Komoju/Payments/Controller/HostedPage/Redirect.php
@@ -64,7 +64,7 @@ class Redirect extends \Magento\Framework\App\Action\Action
 
         return parent::__construct($context);
     }
-    
+
     public function execute()
     {
         $hostedPageUrl = $this->createHostedPageUrl();
@@ -144,7 +144,7 @@ class Redirect extends \Magento\Framework\App\Action\Action
             "transaction[customer][given_name]" => $billingAddress->getFirstname(),
             "transaction[customer][family_name]" => $billingAddress->getLastname(),
             "transaction[customer][phone]" => $billingAddress->getTelephone(),
-            "transaction[tax]" => $order->getTaxAmount(),
+            "transaction[tax]" => 0,
             "timestamp" => time(),
             "transaction[return_url]" => $this->_url->getUrl('checkout/onepage/success'),
             "transaction[cancel_url]" => $this->_url->getUrl($cancelUrl),


### PR DESCRIPTION
Passing a value in the tax param isn't necessary, since `$order->getGrandTotal()` should already be a tax inclusive value.