### PR TITLE
Add default MAGENTO_VERSION to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7.3-fpm-buster
 
-ARG MAGENTO_VERSION
+ARG MAGENTO_VERSION=2.3.4
 
 RUN apt-get update && apt-get install -y \
   cron \


### PR DESCRIPTION
A blank arg here causes a build error, so we might as well have a default value (2.3.4 us version used for testing so far)