### PR TITLE
[Feature] Refund

### DIFF
--- a/src/app/code/Komoju/Payments/Controller/HostedPage/Redirect.php
+++ b/src/app/code/Komoju/Payments/Controller/HostedPage/Redirect.php
@@ -125,7 +125,9 @@ class Redirect extends \Magento\Framework\App\Action\Action
           'return_url' => $returnUrl,
           'default_locale' => $this->config->getKomojuLocale(),
           'payment_types' => [$paymentMethod],
+          'email' => $order->getCustomerEmail(),
           'payment_data' => [
+              'name' => $order->getCustomerName(),
               'amount' => $order->getGrandTotal(),
               'currency' => $currencyCode,
               'external_order_num' => $externalOrderNum,

--- a/src/app/code/Komoju/Payments/Controller/HostedPage/Webhook.php
+++ b/src/app/code/Komoju/Payments/Controller/HostedPage/Webhook.php
@@ -166,8 +166,8 @@ class Webhook extends \Magento\Framework\App\Action\Action implements HttpPostAc
      * If it can't find a matching Order then we're assuming that the order belongs
      * to a separate system and ignoring any events sent for it.
      * @var string $externalOrderNum
-     * @return Magento\Sales\Model\Order
-     * @throws Magento\Framework\Exception\NoSuchEntityException
+     * @return \Magento\Sales\Api\Data\OrderInterface
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     private function getOrder($externalOrderNum)
     {

--- a/src/app/code/Komoju/Payments/Model/Refund.php
+++ b/src/app/code/Komoju/Payments/Model/Refund.php
@@ -1,6 +1,9 @@
 <?php
 namespace Komoju\Payments\Model;
 
+use Magento\Framework\Model\AbstractModel;
+use Komoju\Payments\Model\ResourceModel\Refund as RefundResourceModel;
+
 /**
  * The Refund model is for programmatic access to the komoju_refund data.
  *
@@ -12,10 +15,10 @@ namespace Komoju\Payments\Model;
  * creditmemo's that have been created, but that's more of a future proofing act
  * in the event we may need that data.
  */
-class Refund extends \Magento\Framework\Model\AbstractModel
+class Refund extends AbstractModel
 {
     protected function _construct()
     {
-        $this->_init(\Komoju\Payments\Model\ResourceModel\Refund::class);
+        $this->_init(RefundResourceModel::class);
     }
 }

--- a/src/app/code/Komoju/Payments/Model/ResourceModel/Refund/Collection.php
+++ b/src/app/code/Komoju/Payments/Model/ResourceModel/Refund/Collection.php
@@ -1,13 +1,16 @@
 <?php
 namespace Komoju\Payments\Model\ResourceModel\Refund;
 
-use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
+use Magento\Framework\DataObject;
+use Komoju\Payments\Model\Refund as RefundModel;
+use Komoju\Payments\Model\ResourceModel\Refund as RefundResourceModel;
 
 /**
  * The Collection class is an abstraction on top of queries to the database.
- * It's the main interface for access ExternalPayment resources
+ * It's the main interface for access ExternalPayment resources.
  */
-class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection
+class Collection extends AbstractCollection
 {
     /**
      * Defines the resource models the collection is matched to
@@ -16,19 +19,18 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
      */
     protected function _construct()
     {
-        $this->_init(\Komoju\Payments\Model\Refund::class, Komoju\Payments\Model\ResourceModel\Refund::class);
+        $this->_init(RefundModel::class, RefundResourceModel::class);
     }
 
     /**
      * Returns the record that matches the $refundId. If there's no matching
      * record then we assume that the refund has not been processed yet.
      * @param string $refundId
-     * @return Komoju\Payments\Model\Refund|null
+     * @return DataObject|null
      */
     public function getRecordForRefundId($refundId)
     {
-        $collection = $this
-            ->addFieldToFilter('refund_id', ['eq' => $refundId]);
+        $collection = $this->addFieldToFilter('refund_id', ['eq' => $refundId]);
 
         if ($collection->getSize() < 1) {
             return null;


### PR DESCRIPTION
# Description

This update enhances the Komoju-Magento plugin with the following key changes and improvements:

- Addition of Customer Email and Name:
  - Added customer email and name to the hosted page URL parameters to provide better customer context.

![image](https://github.com/degica/komoju-magento/assets/16696001/be33c79e-ca24-43fd-b0d0-13def5ce7657)

- Improved Refund Handling:
  - Implemented refund functionality to handle payment.refunded and payment.refund.created events more effectively.
  - Moved setTotalRefunded method outside of the for-loop block in payment.refund.created event processing to prevent duplication.

- Code Cleanup and Refactoring:
  - Updated various namespaces and class references for consistency and readability.
  - Replaced deprecated methods

## Detailed Changes

### WebhookEventProcessor.php:
  - Set $baseTotalPaid = $this->order->getBaseTotalPaid();
    - Reason for Change:
Without setting baseTotalPaid, the refund logic was throwing errors. This is likely because the validation method validate checks if the base order refund exceeds the base total paid. If baseTotalPaid is not correctly set, this check can fail and cause errors when writing credit memo.

https://github.com/pepe1518/magento2/blob/master/vendor/magento/module-sales/Model/Service/CreditmemoService.php#L213
```php
public function validate($entity)
{
    $messages = [];
    $baseOrderRefund = $this->priceCurrency->round(
        $entity->getOrder()->getBaseTotalRefunded() + $entity->getBaseGrandTotal()
    );
    if ($baseOrderRefund > $this->priceCurrency->round($entity->getOrder()->getBaseTotalPaid())) {
        $baseAvailableRefund = $entity->getOrder()->getBaseTotalPaid()
            - $entity->getOrder()->getBaseTotalRefunded();

        $messages[] = __(
            'The most money available to refund is %1.',
            $baseAvailableRefund
        );
    }

    return $messages;
}
```

  - Added logic to set the order state to complete if the total amount refunded matches the order's base grand total, which means when it is fully refunded. It is still set as processing based on the adobe commerce's spec.

```php

if ($this->order->getBaseGrandTotal() == $totalAmountRefunded) {
    $this->order->setState(Order::STATE_COMPLETE);
    $this->order->setStatus(Order::STATE_COMPLETE);
}
```

Quote from: https://experienceleague.adobe.com/en/docs/commerce-admin/stores-sales/order-management/orders/order-status
> A partially refunded order remains in Processing status until all ordered items (including refunded items) are shipped. The order status does not change to Complete until every item in the order has been shipped.

- Set the shipping amount to 0 for the credit memo:
  - This ensures we only write the subtotal since the specific refunded items are unknown, and it avoids potential inaccuracies with shipping refunds.

![image](https://github.com/degica/komoju-magento/assets/16696001/05a44d6c-5838-4101-8b15-27e20f8ff891)


## Attachments

### How it looks like after processing 3 partial refund
![image](https://github.com/degica/komoju-magento/assets/16696001/db939018-a441-4f76-9a16-2a3ce5017721)

![image](https://github.com/degica/komoju-magento/assets/16696001/d1d458ef-f107-488f-93e7-cd9973697289)


Please review these changes and merge the PR if everything looks good. Thank you!