### PR TITLE
Fix typo in en_US.csv

### DIFF
--- a/src/app/code/Komoju/Payments/i18n/en_US.csv
+++ b/src/app/code/Komoju/Payments/i18n/en_US.csv
@@ -9,7 +9,7 @@ Konbini,Konbini
 "Order has been fully refunded.","Order has been fully refunded."
 "Refund for order created. Amount: %1 %2","Refund for order created. Amount: %1 %2"
 "Unknown event type: %1","Unknown event type: %1"
-"KOMOJU - %1","KOOJU - %1",
+"KOMOJU - %1","KOMOJU - %1",
 "External Order ID: %1 %2","External Order ID: %1 %2"
 "Payment Type","Payment Type"
 "Place Order","Place Order"


### PR DESCRIPTION
# Description

I realized that there is typo issue in en_US.csv

```
"KOMOJU - %1","KOOJU - %1",
```

It should be KOMOJU not KOOJU.