### PR TITLE
Fix error when cancelling order in admin page

### DIFF
--- a/src/app/code/Komoju/Payments/Observer/RestoreAfterCancel.php
+++ b/src/app/code/Komoju/Payments/Observer/RestoreAfterCancel.php
@@ -31,7 +31,9 @@ class RestoreAfterCancel implements ObserverInterface
 
         if (!$lastRealQuoteId) {
             $quote = $observer->getEvent()->getQuote();
-            $quote->setIsActive(true);
+            if ($quote) {
+                $quote->setIsActive(true);
+            }
             return;
         }
 


### PR DESCRIPTION
# Description

Reported in #20, it was unable to cancel order through Magneto.
Previously,   `RestoreAfterCancel` event listener is created for restore quote for when `user` is cancelling the order. However, in the Admin page this was also called after when the order has been cancelled. And was throwing error, since the quote is null.
By adding null check this problem has been fixed.