### PR TITLE
CPF-265 Remove LINE pay method from the list

### DIFF
--- a/src/app/code/Komoju/Payments/Model/Ui/ConfigProvider.php
+++ b/src/app/code/Komoju/Payments/Model/Ui/ConfigProvider.php
@@ -116,6 +116,9 @@ class ConfigProvider implements ConfigProviderInterface
 
             $methods = $this->komojuApi->paymentMethods();
             foreach ($methods as $method) {
+                if ($method->type_slug === 'linepay') {
+                    continue;
+                }
                 $paymentMethodOptions[$method->type_slug] = $method->{"name_{$locale}"};
             }
             return $paymentMethodOptions;


### PR DESCRIPTION
# Description

LINE Pay has been discontinued, but it is still appearing on the frontend as an available payment option. To prevent confusion for our users, we are removing LINE Pay from the displayed payment methods. This change ensures that deprecated services are no longer visible to customers and improves the clarity of our payment interface.