### PR TITLE
Fix PHP 8.4 implicit nullable deprecation breaking Marketplace validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ After configuring, click "Create Webhook" to save your settings.
 
 Back in your Magento plugin configuration, enter the webhook secret you created into the "Webhook Secret Token" field.
 
+## Building the zip for Adobe Marketplace submission
+
+Adobe Marketplace requires `composer.json` and `registration.php` at the root of the archive. Zip from inside the extension directory, excluding `.DS_Store` and `composer.lock`:
+
+```shell
+cd src/app/code/Komoju/Payments
+zip -r ~/komoju-payments.zip . -x "*.DS_Store" "composer.lock"
+```
+
 ## Contact Us
 
 For questions or concerns, contact our support team at support@degica.com.

--- a/src/app/code/Komoju/Payments/Controller/HostedPage/PostSessionRedirect.php
+++ b/src/app/code/Komoju/Payments/Controller/HostedPage/PostSessionRedirect.php
@@ -40,9 +40,9 @@ class PostSessionRedirect extends Action
         ResultFactory $resultFactory,
         Context $context,
         Config $config,
-        ?LoggerInterface $logger = null,
         Session $checkoutSession,
-        KomojuApi $komojuApi
+        KomojuApi $komojuApi,
+        ?LoggerInterface $logger = null
     ) {
         $this->logger = $logger ?: ObjectManager::getInstance()->get(\Psr\Log\LoggerInterface::class);
         $this->_resultFactory = $resultFactory;

--- a/src/app/code/Komoju/Payments/Controller/HostedPage/PostSessionRedirect.php
+++ b/src/app/code/Komoju/Payments/Controller/HostedPage/PostSessionRedirect.php
@@ -40,7 +40,7 @@ class PostSessionRedirect extends Action
         ResultFactory $resultFactory,
         Context $context,
         Config $config,
-        LoggerInterface $logger = null,
+        ?LoggerInterface $logger = null,
         Session $checkoutSession,
         KomojuApi $komojuApi
     ) {

--- a/src/app/code/Komoju/Payments/Controller/HostedPage/Redirect.php
+++ b/src/app/code/Komoju/Payments/Controller/HostedPage/Redirect.php
@@ -65,9 +65,9 @@ class Redirect extends \Magento\Framework\App\Action\Action
         \Magento\Checkout\Model\Session $checkoutSession,
         \Komoju\Payments\Gateway\Config\Config $config,
         \Magento\Store\Model\StoreManagerInterface $storeManager,
-        ?\Psr\Log\LoggerInterface $logger = null,
         \Komoju\Payments\Api\KomojuApi $komojuApi,
-        \Magento\Directory\Model\CountryFactory $countryFactory
+        \Magento\Directory\Model\CountryFactory $countryFactory,
+        ?\Psr\Log\LoggerInterface $logger = null
     ) {
         $this->logger = $logger ?: ObjectManager::getInstance()->get(\Psr\Log\LoggerInterface::class);
         $this->externalPayment = $externalPaymentFactory->create();

--- a/src/app/code/Komoju/Payments/Controller/HostedPage/Redirect.php
+++ b/src/app/code/Komoju/Payments/Controller/HostedPage/Redirect.php
@@ -65,7 +65,7 @@ class Redirect extends \Magento\Framework\App\Action\Action
         \Magento\Checkout\Model\Session $checkoutSession,
         \Komoju\Payments\Gateway\Config\Config $config,
         \Magento\Store\Model\StoreManagerInterface $storeManager,
-        \Psr\Log\LoggerInterface $logger = null,
+        ?\Psr\Log\LoggerInterface $logger = null,
         \Komoju\Payments\Api\KomojuApi $komojuApi,
         \Magento\Directory\Model\CountryFactory $countryFactory
     ) {

--- a/src/app/code/Komoju/Payments/Controller/HostedPage/Webhook.php
+++ b/src/app/code/Komoju/Payments/Controller/HostedPage/Webhook.php
@@ -79,7 +79,7 @@ class Webhook extends \Magento\Framework\App\Action\Action implements HttpPostAc
         \Komoju\Payments\Model\ExternalPaymentFactory $externalPaymentFactory,
         \Komoju\Payments\Model\RefundFactory $komojuRefundFactory,
         \Komoju\Payments\Gateway\Config\Config $config,
-        \Psr\Log\LoggerInterface $logger = null
+        ?\Psr\Log\LoggerInterface $logger = null
     ) {
         $this->logger = $logger ?: ObjectManager::getInstance()->get(\Psr\Log\LoggerInterface::class);
         $this->_resultFactory = $resultFactory;

--- a/src/app/code/Komoju/Payments/Model/Ui/ConfigProvider.php
+++ b/src/app/code/Komoju/Payments/Model/Ui/ConfigProvider.php
@@ -61,8 +61,8 @@ class ConfigProvider implements ConfigProviderInterface
         Config $config,
         SessionManagerInterface $session,
         ScopeConfigInterface $scopeConfig,
-        ?\Psr\Log\LoggerInterface $logger = null,
-        \Komoju\Payments\Api\KomojuApi $komojuApi
+        \Komoju\Payments\Api\KomojuApi $komojuApi,
+        ?\Psr\Log\LoggerInterface $logger = null
     ) {
         $this->config = $config;
         $this->session = $session;

--- a/src/app/code/Komoju/Payments/Model/Ui/ConfigProvider.php
+++ b/src/app/code/Komoju/Payments/Model/Ui/ConfigProvider.php
@@ -61,7 +61,7 @@ class ConfigProvider implements ConfigProviderInterface
         Config $config,
         SessionManagerInterface $session,
         ScopeConfigInterface $scopeConfig,
-        \Psr\Log\LoggerInterface $logger = null,
+        ?\Psr\Log\LoggerInterface $logger = null,
         \Komoju\Payments\Api\KomojuApi $komojuApi
     ) {
         $this->config = $config;

--- a/src/app/code/Komoju/Payments/Observer/PaymentMethodAvailable.php
+++ b/src/app/code/Komoju/Payments/Observer/PaymentMethodAvailable.php
@@ -40,7 +40,7 @@ class PaymentMethodAvailable implements ObserverInterface
         \Magento\Store\Model\StoreManagerInterface $storeManager,
         $methodCode,
         $allowableCurrencyCodes,
-        \Psr\Log\LoggerInterface $logger = null
+        ?\Psr\Log\LoggerInterface $logger = null
     ) {
         $this->storeManager = $storeManager;
         $this->methodCode = $methodCode;

--- a/src/app/code/Komoju/Payments/Observer/RestoreAfterCancel.php
+++ b/src/app/code/Komoju/Payments/Observer/RestoreAfterCancel.php
@@ -18,7 +18,7 @@ class RestoreAfterCancel implements ObserverInterface
     public function __construct(
         CheckoutSession $checkoutSession,
         CartRepositoryInterface $quoteRepository,
-        LoggerInterface $logger = null
+        ?LoggerInterface $logger = null
     ) {
         $this->checkoutSession = $checkoutSession;
         $this->quoteRepository = $quoteRepository;

--- a/src/app/code/Komoju/Payments/Observer/RestoreQuoteFromSession.php
+++ b/src/app/code/Komoju/Payments/Observer/RestoreQuoteFromSession.php
@@ -29,7 +29,7 @@ class RestoreQuoteFromSession implements ObserverInterface
     public function __construct(
         CheckoutSession $checkoutSession,
         CartRepositoryInterface $quoteRepository,
-        LoggerInterface $logger = null
+        ?LoggerInterface $logger = null
     ) {
         $this->checkoutSession = $checkoutSession;
         $this->quoteRepository = $quoteRepository;

--- a/src/app/code/Komoju/Payments/composer.json
+++ b/src/app/code/Komoju/Payments/composer.json
@@ -2,7 +2,7 @@
     "name": "komoju/payments",
     "description": "Integrates with KOMOJU to provide payment solutions for Magento",
     "type": "magento2-module",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "license": [],
     "autoload": {
         "files": [ "registration.php" ],


### PR DESCRIPTION
## Summary

- Adobe Marketplace submission (varnish + MFTF tests) fails on Magento 2.4.8-p4 / PHP 8.4 because `setup:di:compile` treats implicit nullable parameters (`Type $param = null`) as a deprecation error.
- Updated all 7 affected constructors to use the explicit nullable syntax (`?Type $param = null`).
- Bumped extension version from 1.3.0 to 1.3.1.

## Affected files

- `Model/Ui/ConfigProvider.php` (this was the file flagged in the validation report)
- `Controller/HostedPage/Webhook.php`
- `Controller/HostedPage/Redirect.php`
- `Controller/HostedPage/PostSessionRedirect.php`
- `Observer/PaymentMethodAvailable.php`
- `Observer/RestoreAfterCancel.php`
- `Observer/RestoreQuoteFromSession.php`

## Context

The Adobe Marketplace EQP tool runs `setup:di:compile` on PHP 8.4 (Magento 2.4.8-p4). PHP 8.4 deprecated implicit nullable parameters ([RFC](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)), causing the build step to fail with:

```
Deprecated Functionality: Komoju\Payments\Model\Ui\ConfigProvider::__construct():
Implicitly marking parameter $logger as nullable is deprecated, the explicit
nullable type must be used instead
```

## Test plan

- [ ] Re-submit the extension zip to Adobe Marketplace and verify varnish/MFTF validation passes
- [ ] Verify the extension installs and works on Magento 2.4.8-p4 (PHP 8.4)
- [ ] Verify backward compatibility on PHP 8.1/8.2/8.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)