### PR TITLE
ci: migrate workflows to self-hosted runners

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, on-demand]
     steps:
       - name: Check out
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   php-cs-fixer:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, spot]
     steps:
       - uses: actions/checkout@v4
       - name: Setup PHP
@@ -26,7 +26,7 @@ jobs:
       - name: Run lint
         run: vendor/bin/phpcs --standard=magento2 src/app
   lint-js:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, spot]
     steps:
       - uses: actions/checkout@v4
       - name: Install modules


### PR DESCRIPTION
## Migration summary

Migrate GitHub-hosted runners to self-hosted runners as part of the GitHub org IP allowlist restriction (SEC-627, deadline May 29).

**Runner label mapping:**

| Old | New | Reason |
|-----|-----|--------|
| `ubuntu-latest` | `[self-hosted, on-demand]` | deploy / release — xlarge on-demand (no spot interruption) |
| `ubuntu-latest` | `[self-hosted, spot]` | regular CI — xlarge spot |

**Changed workflows:**

- `.github/workflows/docs.yml`
  - `build-and-deploy` → `on-demand`
- `.github/workflows/lint.yml`
  - `php-cs-fixer` → `spot`
  - `lint-js` → `spot`

If any jobs fail, please ping @harsh-gulhane

**Reference:** [GitHub IP Restriction](https://www.notion.so/GitHub-IP-Restriction-35e0fbdadd16807eb887e963924d92e0)