### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ After installation, configure the plugin in the store configuration under the ad
 
 When configuring the "API Settings" section of the plugin use the following values:
 
-Go to Stores > Configuration > Sales > Payment Methods > KOMOJU > API Settings. Set **Enable this Solution** to **Yes**, then fill out below:
+Go to Stores > Configuration > Sales > Payment Methods, expand Additional Payment Solutions (or similar group) to find KOMOJU. Set **Enable this Solution** to **Yes**, then expand API Settings and fill out below:
 
 Merchant UUID: Your UUID
 Secret Key: Secret Key

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This plugin allows for Magento store owners to accept payments with [Komoju paym
 3. Unzip the file directly into your $MAGENTO_INSTALL/app/code directory, where $MAGENTO_INSTALL is the directory where Magento is installed:
 
 ```shell
-$ unzip komoju-magento-release.zip -d $MAGENTO_INSTALL/src/app/code
+$ unzip komoju-magento-release.zip -d $MAGENTO_INSTALL/app/code
 ```
 
 4. Install the new module with the following commands:
@@ -34,12 +34,12 @@ After installation, configure the plugin in the store configuration under the ad
 
 When configuring the "API Settings" section of the plugin use the following values:
 
-Go to Stores > Sales > Payment Methods > Komoju > API Settings and fill out below
+Go to Stores > Configuration > Sales > Payment Methods > KOMOJU > API Settings. Set **Enable this Solution** to **Yes**, then fill out below:
 
 Merchant UUID: Your UUID
 Secret Key: Secret Key
 Publishable Key: Publishable Key
-Webhook Secret: **Wil Explain below**
+Webhook Secret: **Will explain below**
 
 ![Magento Configuration](./docs/en/assets/images/magento_configuration.jpg "KOMOJU dashboard")
 
@@ -66,7 +66,8 @@ And don't forget to choose a secret and ensure the following events are selected
 
 After configuring, click "Create Webhook" to save your settings.
 
-Back in your Magento plugin configuration, enter the webhook secret you created into the "Webhook Secret Token" field.
+Back in your Magento plugin configuration, enter the webhook secret you created into the "Webhook Secret" field.
+
 
 ## Building the zip for Adobe Marketplace submission
 


### PR DESCRIPTION
## https://degica.atlassian.net/browse/CI-1275

We needed to update the Readme with clear instructions for komoju setup in magento apps

## What changed

5 fixes to `README.md` only.

| # | Fix | Was | Now |
|---|---|---|---|
| 1 | Unzip path | `$MAGENTO_INSTALL/src/app/code` | `$MAGENTO_INSTALL/app/code` |
| 2 | Enable step | (missing) | `Set **Enable this Solution** to **Yes**` |
| 3 | Field name | "Webhook Secret Token" | "Webhook Secret" |
| 4 | Nav path | `Stores > Sales > Payment Methods > Komoju` | `Stores > Configuration > Sales > Payment Methods > KOMOJU` |
| 5 | Typo | `Wil Explain below` | `Will explain below` |

## How to validate

Check each fix against the plugin source:

1. **Fix 1** — Magento loads modules from `app/code/`, not `src/app/code/`. The `/src/` path only exists in this dev repo's Docker mount layout.
2. **Fix 2** — `src/app/code/Komoju/Payments/etc/config.xml` ships `<active>0</active>`. The plugin is disabled by default; the old README never told merchants to enable it.
3. **Fix 3** — `src/app/code/Komoju/Payments/etc/adminhtml/system.xml` labels the field `<label>Webhook Secret</label>`. No field named "Webhook Secret Token" exists in the UI.
4. **Fix 4** — Magento's admin menu has a "Configuration" level between "Stores" and "Sales". The section label in `system.xml` is "KOMOJU".
5. **Fix 5** — The original README had a typo: "Wil Explain below" instead of "Will explain below". The corrected text is visible in the diff and in the README itself.


## Below shows the correct route to enabling Komoju

https://github.com/user-attachments/assets/793c04d8-99d5-4df8-b621-69d48afdf8db
